### PR TITLE
Removes check for lastpos === element.scrolltop Fixes safari bug

### DIFF
--- a/animatedScrollTo.js
+++ b/animatedScrollTo.js
@@ -21,18 +21,8 @@
             }
             requestAnimFrame(animateScroll);
             var now = +new Date();
-            var val = Math.floor(easeInOutQuad(now - animationStart, start, change, duration));
-            if (lastpos) {
-                if (lastpos === element.scrollTop) {
-                    lastpos = val;
-                    element.scrollTop = val;
-                } else {
-                    animating = false;
-                }
-            } else {
-                lastpos = val;
-                element.scrollTop = val;
-            }
+            lastpos = element.scrollTop = Math.floor(easeInOutQuad(now - animationStart, start, change, duration));
+
             if (now > animationStart + duration) {
                 element.scrollTop = to;
                 animating = false;


### PR DESCRIPTION
`animatedScrollTo` is broken in Safari. Whenever `lastpos !== element.scrolltop` it kills the `animation` even before reaching the desired position to scroll `to`.
We are already returning false and stopping the animation once already in `now > animationStart + duration`.
![screen shot 2014-10-29 at 10 58 28 pm](https://cloud.githubusercontent.com/assets/4733664/4839149/ed1e4498-5ff9-11e4-865b-836f1aa6c26e.png)
![screen shot 2014-10-29 at 10 59 49 pm](https://cloud.githubusercontent.com/assets/4733664/4839157/0b56cef8-5ffa-11e4-9c4f-4c2797f739cd.png)
