### PR TITLE
Made options for scrollLeft and fix callback bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ button.addEventListener('click', function () {
         document.body, // element to scroll with (most of times you want to scroll with whole <body>)
         0, // target scrollY (0 means top of the page)
         10000, // duration in ms
+        true, // horizontal scrolling?
         function() { // callback function that runs after the animation (optional)
           console.log('done!')
         }

--- a/animatedScrollTo.js
+++ b/animatedScrollTo.js
@@ -21,6 +21,7 @@
 
         var animateScroll = function() {
             if (!animating) {
+                if (callback) { callback(); }
                 return;
             }
             requestAnimFrame(animateScroll);
@@ -40,7 +41,6 @@
             if (now > animationStart + duration) {
                 element[direction] = to;
                 animating = false;
-                if (callback) { callback(); }
             }
         };
         requestAnimFrame(animateScroll);

--- a/animatedScrollTo.js
+++ b/animatedScrollTo.js
@@ -8,8 +8,12 @@
         return -c/2 * (t*(t-2) - 1) + b;
     };
 
-    var animatedScrollTo = function (element, to, duration, callback) {
-        var start = element.scrollTop,
+    var animatedScrollTo = function (element, to, duration, scrollLeft, callback) {
+        
+        var direction = 'scrollTop'
+        if (scrollLeft) direction = 'scrollLeft'
+        
+        var start = element[direction],
         change = to - start,
         animationStart = +new Date();
         var animating = true;
@@ -23,18 +27,18 @@
             var now = +new Date();
             var val = Math.floor(easeInOutQuad(now - animationStart, start, change, duration));
             if (lastpos) {
-                if (lastpos === element.scrollTop) {
+                if (lastpos === element[direction]) {
                     lastpos = val;
-                    element.scrollTop = val;
+                    element[direction] = val;
                 } else {
                     animating = false;
                 }
             } else {
                 lastpos = val;
-                element.scrollTop = val;
+                element[direction] = val;
             }
             if (now > animationStart + duration) {
-                element.scrollTop = to;
+                element[direction] = to;
                 animating = false;
                 if (callback) { callback(); }
             }


### PR DESCRIPTION
Hi there!
I love your little script, useful indeed. But I wanted it to be able to use with horizontal scroll too. I made this modification. I followed you arguments pattern. But actually its better to pass in an option object, its more convenient if in the future some more options could be added.

I also found that if the scroll distance is more than the actual scrolling width the callback doesn't fire, I move the callback when It detects its not animating.
