### PR TITLE
Fixed issue with Chrome zoom

### DIFF
--- a/animatedScrollTo.js
+++ b/animatedScrollTo.js
@@ -23,8 +23,8 @@
             var now = +new Date();
             var val = Math.floor(easeInOutQuad(now - animationStart, start, change, duration));
             if (lastpos === element.scrollTop) {
-                lastpos = val;
                 element.scrollTop = val;
+                lastpos = element.scrollTop;
             } else {
                 animating = false;
             }

--- a/animatedScrollTo.js
+++ b/animatedScrollTo.js
@@ -13,7 +13,7 @@
         change = to - start,
         animationStart = +new Date();
         var animating = true;
-        var lastpos = null;
+        var lastpos = start;
 
         var animateScroll = function() {
             if (!animating) {
@@ -22,16 +22,11 @@
             requestAnimFrame(animateScroll);
             var now = +new Date();
             var val = Math.floor(easeInOutQuad(now - animationStart, start, change, duration));
-            if (lastpos) {
-                if (lastpos === element.scrollTop) {
-                    lastpos = val;
-                    element.scrollTop = val;
-                } else {
-                    animating = false;
-                }
-            } else {
+            if (lastpos === element.scrollTop) {
                 lastpos = val;
                 element.scrollTop = val;
+            } else {
+                animating = false;
             }
             if (now > animationStart + duration) {
                 element.scrollTop = to;


### PR DESCRIPTION
On Chrome, when the zoom is active, the following behavior is observed : 

``` javascript
document.body.scrollTop = 5;
document.body.scrollTop; // 4.545454446934474
```

See https://bugs.chromium.org/p/chromium/issues/detail?id=507801

As a result the animated scroll doesn't work when the zoom is active. This PR fixes that by setting `lastpos` with the actual value of `element.scrollTop`.

Fixes https://github.com/madebysource/animated-scrollto/issues/5
