### PR TITLE
Adds cancel method

### DIFF
--- a/animatedScrollTo.js
+++ b/animatedScrollTo.js
@@ -40,6 +40,9 @@
             }
         };
         requestAnimFrame(animateScroll);
+        return function cancel() {
+            animating = false;
+        };
     };
 
     if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animated-scrollto",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Animated scrolling without any dependency on libraries",
   "main": "animatedScrollTo.js",
   "repository": {


### PR DESCRIPTION
This is needed because multiple calls to animatedScrollTo in a sufficiently short period of time
may conflict, and cause unexpected issues.